### PR TITLE
add jquery event namespace to main click handler to allow targeted unbind

### DIFF
--- a/ui/main/game/live_game/live_game.js
+++ b/ui/main/game/live_game/live_game.js
@@ -3162,7 +3162,7 @@ $(document).ready(function () {
             holodeckModeMouseDown['command_' + command] = holodeckCommandMouseDown(command, targetable);
         }
 
-        $holodeck.mousedown(function (mdevent) {
+        $holodeck.on('mousedown.stock', function (mdevent) {
             if (mdevent.target.nodeName !== 'HOLODECK')
                 return;
 


### PR DESCRIPTION
[jQuery Event Namespacing](https://api.jquery.com/on/)

Use case: [Live Game Input Refactor](https://forums.uberent.com/threads/rel-live-game-input-refactor.70614/) currently does an unconditional unbind of the main mousedown handler in order to replace it.

```
  //  :-( :-( :-(
  $('holodeck').off('mousedown')
```

This unbinds all mousedown handlers and might have side effects on other layered mousedown handlers.
