### PR TITLE
Improve modability of build bar

### DIFF
--- a/ui/main/game/live_game/live_game.js
+++ b/ui/main/game/live_game/live_game.js
@@ -3440,6 +3440,25 @@ $(document).ready(function () {
         }
         self.armyId.subscribe(self.sendPlayerInfo);
         self.playerData.subscribe(self.sendPlayerInfo);
+
+        // nuke hack
+        // the projectiles are not magically added to the unit_list, so the display details aren't sent to the ui
+        self.ammoBuildHover = {
+            '/pa/units/land/nuke_launcher/nuke_launcher_ammo.json': {
+                name: '!LOC:LR-96 -Pacifier- Missile',
+                description: '!LOC:Nuclear missile - Long range, large area damage, projectile.',
+                cost: api.content.usingTitans() ? 30000 : 50000,
+                sicon_override: 'nuke_launcher_ammo',
+                damage: 33000
+            },
+            '/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json': {
+                name: '!LOC:SR-24 -Shield- Missile Defense',
+                description: '!LOC:Anti-nuke - Intercepts incoming nuclear missiles.',
+                cost: api.content.usingTitans() ? 5000 : 6750,
+                sicon_override: 'anti_nuke_launcher_ammo',
+                damage: 1
+            },
+        };
     }
     model = new LiveGameViewModel();
 
@@ -3625,7 +3644,7 @@ $(document).ready(function () {
 
     handlers.unit_specs = function (payload) {
         delete payload.message_type;
-        model.unitSpecs = payload;
+        model.unitSpecs = _.assign(payload, model.ammoBuildHover);
 
         // Fix up cross-unit references
         function crossRef(units) {
@@ -3682,16 +3701,6 @@ $(document).ready(function () {
                     }
                 }
             });
-
-
-            // nuke hack
-            // the projectiles are not magically added to the unit_list, so the display details aren't sent to the ui
-
-            var nuke_id = '/pa/units/land/nuke_launcher/nuke_launcher_ammo.json';
-            var anti_nuke_id = '/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json';
-
-            model.itemDetails[nuke_id] = new UnitDetailModel({ name: '!LOC:LR-96 -Pacifier- Missile', description: '!LOC:Nuclear missile - Long range, large area damage, projectile.',  cost: 50000, sicon: siconFor(nuke_id), damage: 33000 });
-            model.itemDetails[anti_nuke_id] = new UnitDetailModel({ name: '!LOC:SR-24 -Shield- Missile Defense', description: '!LOC:Anti-nuke - Intercepts incoming nuclear missiles.', cost: 6750, sicon: siconFor(anti_nuke_id), damage: 1 });
 
             // tell any panels that want unit data about the units we just got
             model.sendUnitData();

--- a/ui/main/game/live_game/live_game_build_bar.js
+++ b/ui/main/game/live_game/live_game_build_bar.js
@@ -51,40 +51,24 @@ $(document).ready(function () {
         // Maps a build item spec id to a BuildItem
         self.buildItems = ko.observable({});
         // Maintains the tab list
-        self.tabs = ko.observableArray([
-            new model.BuildTab('factory', '!LOC:factory', true),
-            new model.BuildTab('combat', '!LOC:combat', true),
-            new model.BuildTab('utility', '!LOC:utility', true),
-            new model.BuildTab('vehicle', '!LOC:vehicle'),
-            new model.BuildTab('bot', '!LOC:bot'),
-            new model.BuildTab('air', '!LOC:air'),
-            new model.BuildTab('sea', '!LOC:sea'),
-            new model.BuildTab('orbital', '!LOC:orbital', true),
-            new model.BuildTab('orbital_structure', 'orbital structure', true),
-            new model.BuildTab('ammo', '!LOC:ammo', true)
-        ]);
-        var tabOrder = _.invert([
-            'factory',
-            'combat',
-            'utility',
-            'vehicle',
-            'bot',
-            'air',
-            'sea',
-            'orbital',
-            'orbital_structure',
-            'ammo'
-        ]);
+        self.tabs = ko.observableArray(
+            BuildSet.tabsTemplate.map(function(template) {
+                return new model.BuildTab(template[0], template[1], template[2])
+            })
+        );
+        self.tabOrder = _.invert(self.tabs().map(function(tab) {
+            return tab.group()
+        }));
         var maxIndex = 0;
         _.forIn(grid, function(tabInfo, spec) {
             var unit = units[spec + specTag];
             if (!unit)
                 return;
             var item = new model.BuildItem(unit);
-            var tab = self.tabs()[tabOrder[item.buildGroup]];
+            var tab = self.tabs()[self.tabOrder[item.buildGroup]];
             if (!tab)
             {
-                tabOrder[item.buildGroup] = self.tabs().length;
+                self.tabOrder[item.buildGroup] = self.tabs().length;
                 tab = new model.BuildTab(item.buildGroup);
                 self.tabs().push(tab);
             }
@@ -130,7 +114,7 @@ $(document).ready(function () {
                     item.empty(false);
                     minIndex = Math.min(unit.buildIndex, minIndex);
                     if (!visibleTabs[unit.buildGroup]) {
-                        var tabIndex = tabOrder[item.buildGroup];
+                        var tabIndex = self.tabOrder[item.buildGroup];
                         var tab = tabs[tabIndex];
                         visibleTabs[unit.buildGroup] = tab;
                         if (tab)
@@ -214,6 +198,19 @@ $(document).ready(function () {
             return !!self.tabsByGroup()[group];
         };
     }
+
+    BuildSet.tabsTemplate = [
+        ['factory', '!LOC:factory', true],
+        ['combat', '!LOC:combat', true],
+        ['utility', '!LOC:utility', true],
+        ['vehicle', '!LOC:vehicle'],
+        ['bot', '!LOC:bot'],
+        ['air', '!LOC:air'],
+        ['sea', '!LOC:sea'],
+        ['orbital', '!LOC:orbital', true],
+        ['orbital_structure', 'orbital structure', true],
+        ['ammo', '!LOC:ammo', true]
+    ];
 
     function BuildBarViewModel() {
         var self = this;

--- a/ui/main/game/live_game/live_game_build_bar.js
+++ b/ui/main/game/live_game/live_game_build_bar.js
@@ -4,9 +4,6 @@ var handlers = {};
 
 $(document).ready(function () {
 
-    var ROWS_PER_TAB = 3;
-    var ITEMS_PER_ROW = 6;
-
     function BuildItem(params) {
         var self = this;
 
@@ -30,9 +27,12 @@ $(document).ready(function () {
         self.hotkey = ko.observable('');
         self.active = ko.observable(false);
         self.visible = ko.observable(false);
-        self.itemCount = ko.observable(ITEMS_PER_ROW * ROWS_PER_TAB);
+        self.itemCount = ko.observable(BuildTab.ITEMS_PER_ROW * BuildTab.ROWS_PER_TAB);
         self.skipLastRow = ko.observable(!!skipLastRow);
     }
+
+    BuildTab.ROWS_PER_TAB = 3;
+    BuildTab.ITEMS_PER_ROW = 6;
 
     function BuildSet(params) {
         var units = params.units;
@@ -41,22 +41,27 @@ $(document).ready(function () {
         var specTag = params.specTag;
         var self = this;
 
+        self.units = units;
+        // buildLists captured later
+        self.grid = grid;
+        self.specTag = specTag;
+
         // Maps a spec in the current selection to a build list
         self.selectedSpecs = ko.observable({});
         // Maps a build item spec id to a BuildItem
         self.buildItems = ko.observable({});
         // Maintains the tab list
         self.tabs = ko.observableArray([
-            new BuildTab('factory', '!LOC:factory', true),
-            new BuildTab('combat', '!LOC:combat', true),
-            new BuildTab('utility', '!LOC:utility', true),
-            new BuildTab('vehicle', '!LOC:vehicle'),
-            new BuildTab('bot', '!LOC:bot'),
-            new BuildTab('air', '!LOC:air'),
-            new BuildTab('sea', '!LOC:sea'),
-            new BuildTab('orbital', '!LOC:orbital', true),
-            new BuildTab('orbital_structure', 'orbital structure', true),
-            new BuildTab('ammo', '!LOC:ammo', true)
+            new model.BuildTab('factory', '!LOC:factory', true),
+            new model.BuildTab('combat', '!LOC:combat', true),
+            new model.BuildTab('utility', '!LOC:utility', true),
+            new model.BuildTab('vehicle', '!LOC:vehicle'),
+            new model.BuildTab('bot', '!LOC:bot'),
+            new model.BuildTab('air', '!LOC:air'),
+            new model.BuildTab('sea', '!LOC:sea'),
+            new model.BuildTab('orbital', '!LOC:orbital', true),
+            new model.BuildTab('orbital_structure', 'orbital structure', true),
+            new model.BuildTab('ammo', '!LOC:ammo', true)
         ]);
         var tabOrder = _.invert([
             'factory',
@@ -75,12 +80,12 @@ $(document).ready(function () {
             var unit = units[spec + specTag];
             if (!unit)
                 return;
-            var item = new BuildItem(unit);
+            var item = new model.BuildItem(unit);
             var tab = self.tabs()[tabOrder[item.buildGroup]];
             if (!tab)
             {
                 tabOrder[item.buildGroup] = self.tabs().length;
-                tab = new BuildTab(item.buildGroup);
+                tab = new model.BuildTab(item.buildGroup);
                 self.tabs().push(tab);
             }
             tab.items()[item.buildIndex] = item;
@@ -90,7 +95,7 @@ $(document).ready(function () {
         _.forEach(self.tabs(), function(tab) {
             var items = tab.items();
             tab.items(_.times(tab.itemCount(), function(index) {
-                return items[index] || new BuildItem();
+                return items[index] || new model.BuildItem();
             }));
         });
 
@@ -134,7 +139,7 @@ $(document).ready(function () {
                 });
             });
 
-            minIndex = Math.floor(minIndex / ITEMS_PER_ROW) * ITEMS_PER_ROW;
+            minIndex = Math.floor(minIndex / BuildTab.ITEMS_PER_ROW) * BuildTab.ITEMS_PER_ROW;
 
             // Add empty items
             _.forEach(visibleTabs, function (tab) {
@@ -142,7 +147,7 @@ $(document).ready(function () {
                     var show = index >= minIndex;
 
                     if (show & tab.skipLastRow())
-                        show = ((index + 1) % ITEMS_PER_ROW) != 0;
+                        show = ((index + 1) % BuildTab.ITEMS_PER_ROW) != 0;
 
                     item.visible(show);
                 });
@@ -450,7 +455,7 @@ $(document).ready(function () {
             }
 
             var buildLists = makeBuildLists(payload);
-            self.buildSet(new BuildSet({
+            self.buildSet(new model.BuildSet({
                 units: payload,
                 buildLists: buildLists,
                 grid: self.buildHotkeyModel.SpecIdToGridMap(),
@@ -474,6 +479,10 @@ $(document).ready(function () {
                 window.addEventListener('DOMMouseScroll', sqelch, false);
             window.onmousewheel = document.onmousewheel = sqelch;
         };
+
+        self.BuildItem = BuildItem;
+        self.BuildTab = BuildTab;
+        self.BuildSet = BuildSet;
     }
     model = new BuildBarViewModel();
 

--- a/ui/main/game/live_game/live_game_build_bar.js
+++ b/ui/main/game/live_game/live_game_build_bar.js
@@ -369,7 +369,7 @@ $(document).ready(function () {
             });
         });
 
-        self.unitSpecs.then(function(payload) {
+        self.processUnitSpecs = function(payload) {
             // Fix up cross-unit references
             function crossRef(units) {
                 for (var id in units) {
@@ -458,7 +458,7 @@ $(document).ready(function () {
                 grid: self.buildHotkeyModel.SpecIdToGridMap(),
                 specTag: self.specTag
             }));
-        });
+        };
 
         self.active = ko.observable(true);
 
@@ -495,6 +495,7 @@ $(document).ready(function () {
     handlers.unit_specs = function (payload) {
         delete payload.message_type;
         model.unitSpecs.resolve(payload);
+        model.processUnitSpecs(payload);
     };
 
     handlers.clear_build_sequence = model.clearBuildSequence;


### PR DESCRIPTION
- expose object constructors so new instances can be made
- save their arguments so new properties can be defined
- expose grid dimensions and tab definitions
- extract function for unit specs so it can be either replaced or called again
- expose ammo build hover details
- fix the build hover cost of nuke missiles for titans
