### PR TITLE
remove call to undefined api.camera.setPreviewLinkage

### DIFF
--- a/ui/main/game/live_game/live_game.js
+++ b/ui/main/game/live_game/live_game.js
@@ -2567,10 +2567,6 @@ $(document).ready(function () {
         };
 
         var
-            holodecksRemaining = 0,
-            allHolodecksReady = function() {
-                api.camera.setPreviewLinkage(self.preview, self.holodeck);
-            },
             holodeckReady = function(hdeck) {
                 var focus = api.camera.getFocus(hdeck.id);
                 if (self.cameraFocus[hdeck.name]) {
@@ -2582,9 +2578,6 @@ $(document).ready(function () {
                 if (hdeck.isPrimary) {
                     hdeck.focus();
                 }
-                if (!--holodecksRemaining) {
-                    allHolodecksReady();
-                }
             };
 
         var $holodeck = $('holodeck');
@@ -2592,8 +2585,6 @@ $(document).ready(function () {
         $holodeck.each(function () {
             var $this = $(this);
             var holodeck = new api.Holodeck($this, {}, holodeckReady);
-
-            holodecksRemaining++;
 
             if ($this.is('.primary')) {
                 holodeck.isPrimary = true;


### PR DESCRIPTION
Exception was being [swallowed by a promise](https://forums.uberent.com/threads/missing-error-messages.70537/#post-1124505). It occurred at the tail of processing and isn't _consequential_, but why have an unnecessary exception?
