### PR TITLE
Changed Start Hook, Community Mods Scene and LoadScript Helper To Support Offline

### DIFF
--- a/ui/main/game/community_mods/community_mods.css
+++ b/ui/main/game/community_mods/community_mods.css
@@ -1,5 +1,0 @@
-﻿#community-mods {
-    position:absolute;
-    width:100%;
-    height:100%;
-}

--- a/ui/main/game/community_mods/community_mods.html
+++ b/ui/main/game/community_mods/community_mods.html
@@ -5,10 +5,22 @@
     <noloc><title>Community Mods</title></noloc>
     <link href="bundle://boot/boot.css" rel="stylesheet" type="text/css" />
     <link href="coui://ui/main/shared/css/landing_page.css" rel="stylesheet" type="text/css" />
+    <link href="coui://download/community-mods.css" rel="stylesheet" type="text/css" />
     <script src="bundle://boot/boot.js" type="text/javascript"></script>
-    <script src="coui://ui/main/game/community_mods/community_mods.js" defer type="text/javascript"></script>
+    <script src="coui://download/community-mods.js" defer type="text/javascript"></script>
 </head>
 <body>
-    <div id="community-mods"></div>
+    <div id="community-mods">
+        <div class="background_glow"></div>
+        <!-- TITLE -->
+        <div class="section_title">
+            <div class="content">
+                <div class="btn_std_ix btn_back_small" onclick="window.history.back()">
+                    <span class="glyphicon glyphicon-chevron-left carat"></span>
+                </div>
+                <div class="title">Community Mods</div>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/ui/main/game/community_mods/community_mods.js
+++ b/ui/main/game/community_mods/community_mods.js
@@ -1,8 +1,0 @@
-﻿var url = decode( sessionStorage['community_mods_url']);
-
-if (url) {
-    loadScript( url );
-}
-else {
-    window.history.back();
-}

--- a/ui/main/game/start/start.js
+++ b/ui/main/game/start/start.js
@@ -4,8 +4,6 @@ if ( ! scene_mod_list.start ) {
     scene_mod_list.start = [];
 }
 
-scene_mod_list.start.push('https://dfpsrd4q7p23m.cloudfront.net/community-mods/start.js' );
-
 $(document).ready(function () {
     engine.call('game.debug.menuDocumentReady');
 
@@ -1830,6 +1828,11 @@ $(document).ready(function () {
         closeOnEscape: false,
         buttons: CmdButtons
     });
+
+// try a remote load of community mods and if that fails try the download cache for offline use
+    if (!loadScript( 'https://dfpsrd4q7p23m.cloudfront.net/community-mods/start.js')) {
+        loadScript( 'coui://download/community-mods-start.js');
+    }
 
     // inject per scene mods
     if (scene_mod_list['start'])

--- a/ui/main/shared/js/helpers.js
+++ b/ui/main/shared/js/helpers.js
@@ -46,16 +46,17 @@ function loadScript(src) {
         o.send('');
     } catch (err) {
         console.log("error loading " + src);
-        return;
+        return false;
     }
     if (o.status > 200) {
         console.log('Failed loading', src, 'Status', o.status);
-        return;
+        return false;
     }
     var se = document.createElement('script');
     se.type = "text/javascript";
     se.text = o.responseText;
     document.getElementsByTagName('head')[0].appendChild(se);
+    return true;
 }
 
 function loadCSS(src) {


### PR DESCRIPTION
- added return success / failure to loadScript helper to support offline mode for community mods when no internet connection
- changed start hook to try a remote load and if that fails try the download cache for offline support
- changed community mods scene to load from download cache (remote code automatically downloads latest to cache)
- added a default back button to community mods scene just in case there is any failure loading cached
