### PR TITLE
Reworked uploading of server mods and added server browser hook

### DIFF
--- a/ui/main/game/replay_loading/replay_loading.js
+++ b/ui/main/game/replay_loading/replay_loading.js
@@ -160,7 +160,11 @@ $(document).ready(function () {
     };
 
     if ( window.CommunityMods ) {
-        CommunityMods();
+        try {
+            CommunityMods();
+        } catch ( e ) {
+            console.error( e );
+        }
     }
 
     // inject per scene mods

--- a/ui/main/game/server_browser/server_browser.js
+++ b/ui/main/game/server_browser/server_browser.js
@@ -1,6 +1,8 @@
 ﻿var model;
 var handlers;
 
+loadScript( 'coui://download/community-mods-server-browser.js');
+
 $(document).ready(function () {
 
     function ServerBrowserViewModel() {
@@ -853,6 +855,10 @@ $(document).ready(function () {
 
         // Put the updated list back into the observable array
         model.lanGameList(currentLanGames);
+    }
+
+    if ( window.CommunityMods ) {
+        CommunityMods();
     }
 
     // inject per scene mods

--- a/ui/main/game/server_browser/server_browser.js
+++ b/ui/main/game/server_browser/server_browser.js
@@ -858,13 +858,15 @@ $(document).ready(function () {
     }
 
     if ( window.CommunityMods ) {
-        CommunityMods();
+        try {
+            CommunityMods();
+        } catch ( e ) {
+            console.error( e );
+        }
     }
 
-    // inject per scene mods
-    if (scene_mod_list['server_browser']) {
-        loadMods(scene_mod_list['server_browser']);
-    }
+    loadSceneMods('server_browser');
+
 
     // setup send/recv messages and signals
     app.registerWithCoherent(model, handlers);

--- a/ui/main/game/server_browser/server_browser.js
+++ b/ui/main/game/server_browser/server_browser.js
@@ -1,7 +1,7 @@
 ﻿var model;
 var handlers;
 
-loadScript( 'coui://download/community-mods-server-browser.js');
+loadScript( 'coui://download/community-mods-server_browser.js');
 
 $(document).ready(function () {
 

--- a/ui/main/game/start/start.js
+++ b/ui/main/game/start/start.js
@@ -1950,12 +1950,14 @@ console.log(JSON.stringify(self.reconnectToGameInfo()));
     });
 
     if ( window.CommunityMods ) {
-        CommunityMods();
+        try {
+            CommunityMods();
+        } catch ( e ) {
+            console.error( e );
+        }
     }
 
-    // inject per scene mods
-    if (scene_mod_list['start'])
-        loadMods(scene_mod_list['start']);
+    loadSceneMods('start');
 
     // setup send/recv messages and signals
     app.registerWithCoherent(model, handlers);


### PR DESCRIPTION
- moved uploading of server mods by host into connect_to_game which fixes many issues with the new game lobby loading without server mods ready and the freezes while server mods are uploading and remounting
- added needsServerModsUpload for hosts starting a game or joining a waiting custom server
- added serverModsUploading while uploading and remounting server mods
- changed server_state handler to upload server mods if needed before redirecting to new_game
- added mount_mod_file_data handler to remount server mods once uploaded then redirect to new_game
- added hook for community mods to server_browser.js (will be used to show missing companion mods prior to joining or spectating games)
